### PR TITLE
Update for new repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# FlowForge Development Environment
+# FlowFuse Development Environment
 
-This repository provides a quick and easy way to setup a local FlowForge development
+This repository provides a quick and easy way to setup a local FlowFuse development
 environment.
 
 ## Getting Started
@@ -22,66 +22,34 @@ environment.
 You can now start developing the code normally in the directories under `packages`.
 
 ```
-flowforge-dev-env
+dev-env
 ├── LICENSE
 ├── README.md
 ├── lib
 ├── package.json
 └── packages
-    ├── flowforge
+    ├── flowfuse
     │   └── ... 
-    ├── forge-ui-components
-    │   └── ... 
-    ├── flowforge-driver-localfs
+    ├── driver-localfs
     │   └── ...
-    ├── flowforge-driver-k8s
-    │   └── ...
-    ├── flowforge-driver-docker
-    │   └── ...
-    ├── flowforge-device-agent
-    │   └── ...
-    ├── flowforge-file-server
-    │   └── ...
-    ├── flowforge-nr-audit-logger
-    │   └── ...
-    ├── flowforge-nr-auth
-    │   └── ...
-    ├── flowforge-nr-launcher
-    │   └── ...
-    ├── flowforge-nr-storage
-    │   └── ...
-    ├── flowforge-nr-theme
-    │   └── ...
-    ├── flowforge-nr-project-nodes
-    │   └── ...
-    ├── flowforge-nr-file-nodes
-    │   └── ...
-    ├── flowforge-nr-persistent-context
-    │   └── ...
-    ├── installer
-    │   └── ...
-    ├── helm
-    │   └── ...
-    └── docker-compose
-        └── ...
-
+    .... and all the other repos
 ```
 
-### Running FlowForge
+### Running FlowFuse
 
-After running `npm run init`, you will be able to start FlowForge with its default
+After running `npm run init`, you will be able to start FlowFuse with its default
 configuration by running:
 
-    cd packages/flowforge
+    cd packages/flowfuse
     npm run start
 
 To run in development mode, where it automatically rebuilds the frontend and restarts
 the application when changes are made, run:
 
-    cd packages/flowforge
+    cd packages/flowfuse
     npm run serve
 
-More details on how to develop FlowForge itself are provided in the [main docs](https://github.com/flowforge/flowforge/tree/main/docs/contribute).
+More details on how to develop FlowFuse itself are provided in the [main docs](https://flowfuse.com/docs/contribute/introduction/).
 
 ### Changing a repos dependencies
 
@@ -112,8 +80,7 @@ For example:
 
 ```
 Package git status
- + flowforge (main *+)
- + forge-ui-components (main)
+ + flowfuse (main *+)
  ...
 ```
 
@@ -132,7 +99,7 @@ npm run git checkout main
 
 ## Why is this needed?
 
-The FlowForge platform consists of a number of npm modules. Each module is maintained
+The FlowFuse platform consists of a number of npm modules. Each module is maintained
 in its own git repository. When developing the code and you need to make changes
 across multiple modules, you want to be sure the your development code is loaded.
 
@@ -168,19 +135,19 @@ You can run any command in all repos using either of the following methods:
 
 ### PostgreSQL
 
-By default FlowForge uses SQLite for development. Given production systems do not
+By default FlowFuse uses SQLite for development. Given production systems do not
 tend to use SQLite but PostgreSQL (PG) it's advised to run PG for development too.
 As prerequisite, one should install PG on their own system.
 
-To use PG as development database ensure `packages/flowforge/etc/flowforge.local.yml`
+To use PG as development database ensure `packages/flowfuse/etc/flowforge.local.yml`
 has `postgres` set as database type. The host must be set to an **absolute** path
-to the root `flowforge-dev-env` repository with `data` appended. For example:
+to the root `FlowFuse/dev-env` repository with `data` appended. For example:
 
 ```yaml
 db:
   logging: false
   type: postgres
-  host: /path/to/flowforge-dev-env/data
+  host: /path/to/flowfuse-dev-env/data
   port: 54321
 ```
 

--- a/lib/commands/checkRenamed.js
+++ b/lib/commands/checkRenamed.js
@@ -1,0 +1,33 @@
+const { existsSync } = require('fs')
+const { log } = require('console')
+const path = require('path')
+
+/**
+ * Check for any renamed repos
+ *
+ * @param {} options
+ */
+async function run (options) {
+    const chalk = (await import('chalk')).default
+
+    let loggedHeader = false
+    for (const [oldPackageName, newPackageName] of Object.entries(options.renamedPackages)) {
+        if (existsSync(path.join(options.packageDir, oldPackageName))) {
+            if (!loggedHeader) {
+                loggedHeader = true
+                log(chalk.redBright(chalk.bold('********************************')))
+                log(chalk.redBright(chalk.bold('Found repos that have been renamed')))
+            }
+            log(`${chalk.redBright(' !')} ${oldPackageName} -> ${newPackageName}`)
+        }
+    }
+    if (loggedHeader) {
+        log(chalk.bold('Run `npm run update-renamed` to rename them'))
+        log(chalk.redBright(chalk.bold('********************************')))
+        process.exit(0)
+    }
+}
+
+module.exports = {
+    run
+}

--- a/lib/commands/git.js
+++ b/lib/commands/git.js
@@ -18,7 +18,7 @@ async function run (options) {
     log(chalk.bold(`Running ${cmd} on all packages`))
     for (let i = 0; i < options.packages.length; i++) {
         if (!existsSync(path.join(options.packageDir, options.packages[i]))) {
-            log(`${chalk.redBright('-')} flowforge/${options.packages[i]}`)
+            log(`${chalk.redBright('-')} FlowFuse/${options.packages[i]}`)
         } else {
             try {
                 const output = await runner(

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -33,18 +33,18 @@ async function run (options) {
             try {
                 await runner(
                     `${options.packages[i]}`,
-                    `git clone https://github.com/flowforge/${options.packages[i]}.git`,
+                    `git clone https://github.com/FlowFuse/${options.packages[i]}.git`,
                     { cwd: options.packageDir }
                 )
                 await runner(
                     `${options.packages[i]}`,
-                    `git remote set-url --push origin git@github.com:flowforge/${options.packages[i]}.git`,
+                    `git remote set-url --push origin git@github.com:FlowFuse/${options.packages[i]}.git`,
                     { cwd: path.join(options.packageDir, options.packages[i]) }
                 )
-                log(`${chalk.greenBright('+')} flowforge/${options.packages[i]}`)
+                log(`${chalk.greenBright('+')} FlowFuse/${options.packages[i]}`)
             } catch (err) {
                 log(`${chalk.redBright('-')} ${options.packages[i]}`)
-                error(`Failed to clone flowforge/${options.packages[i]}: ${err.toString()}`)
+                error(`Failed to clone FlowFuse/${options.packages[i]}: ${err.toString()}`)
                 error(err.stderr)
                 error('Aborting')
                 return
@@ -53,10 +53,10 @@ async function run (options) {
             // Ensure the push remote has been set to the git@ url
             await runner(
                 `${options.packages[i]}`,
-                `git remote set-url --push origin git@github.com:flowforge/${options.packages[i]}.git`,
+                `git remote set-url --push origin git@github.com:FlowFuse/${options.packages[i]}.git`,
                 { cwd: path.join(options.packageDir, options.packages[i]) }
             )
-            log(`${chalk.yellowBright('=')} flowforge/${options.packages[i]}`)
+            log(`${chalk.yellowBright('=')} FlowFuse/${options.packages[i]}`)
         }
     }
 
@@ -72,9 +72,9 @@ async function run (options) {
                 'npm install',
                 { cwd: path.join(options.packageDir, options.npmPackages[i]) }
             )
-            log(`${chalk.greenBright('+')} flowforge/${options.npmPackages[i]}`)
+            log(`${chalk.greenBright('+')} FlowFuse/${options.npmPackages[i]}`)
         } catch (err) {
-            log(`${chalk.redBright('-')} flowforge/${options.npmPackages[i]}`)
+            log(`${chalk.redBright('-')} FlowFuse/${options.npmPackages[i]}`)
             error(`Failed install npm packages for ${options.npmPackages[i]}: ${err.toString()}`)
             error(err.stderr)
             error('Aborting')
@@ -86,7 +86,7 @@ async function run (options) {
     await symlinker.linkPackages(options.extraNpmLinks, options.disabledNpmLinks)
 
     log(`\n${chalk.bold('Building packages')}`)
-    const buildPackages = ['forge-ui-components', 'flowforge']
+    const buildPackages = ['flowfuse']
     for (let i = 0; i < buildPackages.length; i++) {
         const packageName = buildPackages[i]
         try {
@@ -95,9 +95,9 @@ async function run (options) {
                 `${NPM} run build`,
                 { cwd: path.join(options.packageDir, packageName) }
             )
-            log(`${chalk.greenBright('+')} flowforge/${packageName}`)
+            log(`${chalk.greenBright('+')} FlowFuse/${packageName}`)
         } catch (err) {
-            log(`${chalk.redBright('-')} flowforge/${packageName}`)
+            log(`${chalk.redBright('-')} FlowFuse/${packageName}`)
             error(`Failed to build ${packageName}`)
             error(err.stderr)
             error('Aborting')
@@ -141,10 +141,10 @@ async function run (options) {
  * @returns {boolean}
  */
 function usePGDatabase (rootPath) {
-    const flowforgeHome = path.join(rootPath, 'packages', 'flowforge')
-    let configPath = path.join(flowforgeHome, '/etc/flowforge.yml')
-    if (existsSync(path.join(flowforgeHome, '/etc/flowforge.local.yml'))) {
-        configPath = path.join(flowforgeHome, '/etc/flowforge.local.yml')
+    const ffHome = path.join(rootPath, 'packages', 'flowfuse')
+    let configPath = path.join(ffHome, '/etc/flowforge.yml')
+    if (existsSync(path.join(ffHome, '/etc/flowforge.local.yml'))) {
+        configPath = path.join(ffHome, '/etc/flowforge.local.yml')
     }
 
     let ffConfig = {}

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -9,7 +9,7 @@ async function run (options) {
     log(chalk.bold('Package git status'))
     for (let i = 0; i < options.packages.length; i++) {
         if (!existsSync(path.join(options.packageDir, options.packages[i]))) {
-            log(`${chalk.redBright('-')} flowforge/${options.packages[i]}`)
+            log(`${chalk.redBright('-')} FlowFuse/${options.packages[i]}`)
         } else {
             try {
                 const branchResult = await runner(

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -13,7 +13,7 @@ async function run (options) {
     log(chalk.bold('Updating all packages on main branch'))
     for (let i = 0; i < options.packages.length; i++) {
         if (!existsSync(path.join(options.packageDir, options.packages[i]))) {
-            log(`${chalk.redBright('-')} flowforge/${options.packages[i]}`)
+            log(`${chalk.redBright('-')} FlowFuse/${options.packages[i]}`)
         } else {
             try {
                 const branchName = (await runner(

--- a/lib/commands/updateRenamed.js
+++ b/lib/commands/updateRenamed.js
@@ -1,0 +1,41 @@
+const { existsSync } = require('fs')
+const { rename } = require('fs/promises')
+const { log } = require('console')
+const path = require('path')
+
+/**
+ *
+ * @param {} options
+ */
+async function run (options) {
+    const { runner } = await require('../runner')()
+    const chalk = (await import('chalk')).default
+
+    let loggedHeader = false
+    for (const [oldPackageName, newPackageName] of Object.entries(options.renamedPackages)) {
+        const fullPath = path.join(options.packageDir, oldPackageName)
+        if (existsSync(fullPath)) {
+            if (!loggedHeader) {
+                loggedHeader = true
+                log(chalk.redBright(chalk.bold('Updated renamed packages')))
+            }
+            // await rm(fullPath, { recursive: true })
+            log(`${chalk.yellowBright(' -')} ${oldPackageName} ${chalk.yellowBright('=>')} ${newPackageName}`)
+            await runner(
+                newPackageName,
+                `git remote set-url origin https://github.com/FlowFuse/${newPackageName}.git`,
+                { cwd: fullPath }
+            )
+            await runner(
+                newPackageName,
+                `git remote set-url --push origin git@github.com:FlowFuse/${newPackageName}.git`,
+                { cwd: fullPath }
+            )
+            await rename(fullPath, path.join(options.packageDir, newPackageName))
+        }
+    }
+}
+
+module.exports = {
+    run
+}

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -11,45 +11,57 @@ if (!options.command) {
 options.rootDir = path.resolve(path.join(__dirname, '..'))
 options.packageDir = path.resolve(path.join(__dirname, '..', 'packages'))
 options.packages = [
-    'flowforge',
-    'forge-ui-components',
-    'flowforge-driver-localfs',
-    'flowforge-driver-k8s',
-    'flowforge-driver-docker',
-    'flowforge-device-agent',
-    'flowforge-file-server',
-    'flowforge-nr-launcher',
-    'flowforge-nr-project-nodes',
-    'flowforge-nr-file-nodes',
-    'flowforge-nr-persistent-context',
+    'flowfuse',
+    'driver-localfs',
+    'driver-k8s',
+    'driver-docker',
+    'device-agent',
+    'file-server',
+    'nr-launcher',
+    'nr-project-nodes',
+    'nr-file-nodes',
+    'nr-persistent-context',
     'installer',
     'helm',
     'docker-compose'
 ]
 
 options.npmPackages = [
-    'flowforge',
-    'forge-ui-components',
-    'flowforge-driver-localfs',
-    'flowforge-driver-k8s',
-    'flowforge-driver-docker',
-    'flowforge-device-agent',
-    'flowforge-file-server',
-    'flowforge-nr-launcher',
-    'flowforge-nr-project-nodes',
-    'flowforge-nr-file-nodes',
-    'flowforge-nr-persistent-context',
+    'flowfuse',
+    'driver-localfs',
+    'driver-k8s',
+    'driver-docker',
+    'device-agent',
+    'file-server',
+    'nr-launcher',
+    'nr-project-nodes',
+    'nr-file-nodes',
+    'nr-persistent-context',
 ]
 
 options.extraNpmLinks = {
-    'flowforge': ['@flowforge/localfs', '@flowforge/kubernetes', '@flowforge/docker'],
+    'flowfuse': ['@flowforge/localfs', '@flowforge/kubernetes', '@flowforge/docker'],
 }
 
 options.disabledNpmLinks = {
-    'flowforge': ['@flowforge/forge-ui-components'],
 }
 
+options.renamedPackages = {
+    'flowforge': 'flowfuse',
+    'flowforge-driver-localfs': 'driver-localfs',
+    'flowforge-driver-k8s': 'driver-k8s',
+    'flowforge-driver-docker': 'driver-docker',
+    'flowforge-device-agent': 'device-agent',
+    'flowforge-file-server': 'file-server',
+    'flowforge-nr-launcher': 'nr-launcher',
+    'flowforge-nr-project-nodes': 'nr-project-nodes',
+    'flowforge-nr-file-nodes': 'nr-file-nodes',
+    'flowforge-nr-persistent-context': 'nr-persistent-context'
+}
+
+
 options.removedPackages = [
+    'forge-ui-components',
     'flowforge-nr-plugin',
     'flowforge-nr-audit-logger',
     'flowforge-nr-auth',
@@ -61,7 +73,10 @@ options.removedPackages = [
 
 if (options.command === 'remove-unused') {
     require('./commands/removeUnused').run(options)
+} else if (options.command === 'update-renamed') {
+    require('./commands/updateRenamed').run(options)
 } else {
+    require('./commands/checkRenamed').run(options)
     require('./commands/checkRemoved').run(options)
     if (options.command === 'init') {
         require('./commands/init').run(options)

--- a/lib/symlinks.js
+++ b/lib/symlinks.js
@@ -79,15 +79,15 @@ module.exports = class PackageLinker {
                 }
 
                 if (resolvedExistingLinkPath === newLinkPath) {
-                    log(`${chalk.yellowBright('=')} flowforge/${this.npmPackagePaths[i]}`)
+                    log(`${chalk.yellowBright('=')} FlowFuse/${this.npmPackagePaths[i]}`)
                 } else {
                     await this.runner(`npm link for ${this.npmPackagePaths[i]}`, 'npm link', {
                         cwd: path.join(this.packageDir, this.npmPackagePaths[i]),
                     })
-                    log(`${chalk.greenBright('+')} flowforge/${this.npmPackagePaths[i]}`)
+                    log(`${chalk.greenBright('+')} FlowFuse/${this.npmPackagePaths[i]}`)
                 }
             } catch (err) {
-                log(`${chalk.redBright('-')} flowforge/${this.npmPackagePaths[i]}`)
+                log(`${chalk.redBright('-')} FlowFuse/${this.npmPackagePaths[i]}`)
                 error(`Failed to link ${this.npmPackagePaths[i]}: ${err.toString()}`)
                 error(err.stderr)
                 error('Aborting')
@@ -137,11 +137,11 @@ module.exports = class PackageLinker {
                     )
 
                     log(
-                        `${chalk.greenBright('+')} flowforge/${packageToLinkFromPath} linked to ${packageNamesString}`
+                        `${chalk.greenBright('+')} FlowFuse/${packageToLinkFromPath} linked to ${packageNamesString}`
                     )
                 }
             } catch (err) {
-                log(`${chalk.redBright('-')} flowforge/${packageToLinkFromPath}`)
+                log(`${chalk.redBright('-')} FlowFuse/${packageToLinkFromPath}`)
                 error(`Failed install link packages for ${packageToLinkFromPath.name}: ${err.toString()}`)
                 console.log(err)
                 error(err.stderr)

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -4,8 +4,8 @@ module.exports = {
     usage: () => {
         return commandLineUsage([
             {
-                header: 'FlowForge Dev Environment',
-                content: 'Tooling to create a local FlowForge development environment'
+                header: 'FlowFuse Dev Environment',
+                content: 'Tooling to create a local FlowFuse development environment'
             },
             {
                 header: 'Synopsis',

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "flowforge-dev-env",
+  "name": "dev-env",
   "private": true,
   "version": "2.0.0",
-  "description": "A meta repo to create a working FlowForge development environment",
+  "description": "A meta repo to create a working FlowFuse development environment",
   "license": "Apache-2.0",
   "scripts": {
     "init": "node lib/ff-dev-env.js init",
@@ -11,6 +11,7 @@
     "update": "node lib/ff-dev-env.js update",
     "git": "node lib/ff-dev-env.js git",
     "remove-unused": "node lib/ff-dev-env.js remove-unused",
+    "update-renamed": "node lib/ff-dev-env.js update-renamed",
     "check-dependencies": "node lib/ff-dev-env.js check-dependencies"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

Update dev-env for the new repo names.

If it finds any old repos, it prompts you to run `npm run update-renamed` and it will attempt to rename the corresponding directly and update the git remote urls to match.

