### PR TITLE
Add verdaccio to dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 packages/*
 data/*
+verdaccio/storage/

--- a/README.md
+++ b/README.md
@@ -156,3 +156,30 @@ Than run `npm run init` to setup your database.
 Start the server by running `postgres -s -D ./data/pg -k $(pwd)/data -p 54321`
 from the root directory, and keep the terminal window open. Just once you'll
 need to run `createdb -h $(pwd)/data -p 54321 flowforge`.
+
+### Verdaccio
+
+To enable the Team Node Repository, you need a running verdaccio instance configured
+with the authentication plugin for FlowFuse.
+
+To enable, you will need to edit your `packages/flowfuse/etc/flowforge.local.yml` to include:
+
+```yaml
+npmRegistry:
+  enabled: true
+  url: http://localhost:4873
+  admin:
+    username: admin
+    password: secret
+```
+
+To run verdaccio:
+
+```
+cd verdaccio
+npm start
+```
+
+The default configuration file for verdaccio expects the forge app to be running on `http://127.0.0.1:3000`
+If that is not the case, edit `verdaccio/config/config.yaml` with the correct url. 
+

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -86,7 +86,7 @@ async function run (options) {
     await symlinker.linkPackages(options.extraNpmLinks, options.disabledNpmLinks)
 
     log(`\n${chalk.bold('Building packages')}`)
-    const buildPackages = ['flowfuse']
+    const buildPackages = ['flowfuse', 'verdaccio-ff-auth']
     for (let i = 0; i < buildPackages.length; i++) {
         const packageName = buildPackages[i]
         try {
@@ -131,6 +131,22 @@ async function run (options) {
         } else {
             log(`${chalk.redBright('-')} ${pgDir} not empty, skipping`)
         }
+    }
+
+    log(`\n${chalk.bold('Setting up Verdaccio')}`)
+    try {
+        await runner(
+            `npm install - verdaccio`,
+            'npm install',
+            { cwd: path.join(options.rootDir, 'verdaccio') }
+        )
+        log(`${chalk.greenBright('+')} verdaccio`)
+    } catch (err) {
+        log(`${chalk.redBright('-')} verdaccio`)
+        error(`Failed install npm packages for verdaccio: ${err.toString()}`)
+        error(err.stderr)
+        error('Aborting')
+        return
     }
 }
 

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -24,7 +24,8 @@ options.packages = [
     'installer',
     'helm',
     'docker-compose',
-    'mqtt-schema-agent'
+    'mqtt-schema-agent',
+    'verdaccio-ff-auth'
 ]
 
 options.npmPackages = [
@@ -38,7 +39,8 @@ options.npmPackages = [
     'nr-project-nodes',
     'nr-file-nodes',
     'nr-assistant',
-    'mqtt-schema-agent'
+    'mqtt-schema-agent',
+    'verdaccio-ff-auth'
 ]
 
 options.extraNpmLinks = {

--- a/verdaccio/config/config.yaml
+++ b/verdaccio/config/config.yaml
@@ -1,0 +1,9 @@
+storage: ../storage
+auth:
+  ff-auth:
+    baseURL: http://127.0.0.1:3000
+    adminSecret: secret
+packages:
+  '@*/*':
+    access: $authenticated
+log: { type: stdout, format: pretty, level: http }

--- a/verdaccio/package.json
+++ b/verdaccio/package.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "start": "npx verdaccio --config config/config.yaml"
+  },
+  "dependencies": {
+    "verdaccio": "^6.0.5",
+    "verdaccio-ff-auth": "file:../packages/verdaccio-ff-auth"
+  }
+}


### PR DESCRIPTION
Part of #33 

Adds verdaccio setup to dev env.

 - Adds the verdaccio auth plugin to the list of managed repositories.
 - Ensures the auth plugin is built as part of init
 - Adds a `verdaccio` directory with the necessary pieces

After `npm run init`, verdaccio can be run with `npm start` in the `verdaccio` directory.
