### PR TITLE
Update dev-env packge to use npm ci

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -68,8 +68,8 @@ async function run (options) {
     for (let i = 0; i < options.npmPackages.length; i++) {
         try {
             await runner(
-                `npm install - ${options.npmPackages[i]}`,
-                'npm install',
+                `npm ci - ${options.npmPackages[i]}`,
+                'npm ci',
                 { cwd: path.join(options.packageDir, options.npmPackages[i]) }
             )
             log(`${chalk.greenBright('+')} FlowFuse/${options.npmPackages[i]}`)


### PR DESCRIPTION
fixes #41

## Description

<!-- Describe your changes in detail -->
This chooses to install with npm ci rather than npm install when using the `npm run init` to `npm run update` to pull in/update packages managed by the dev env.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#41

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

